### PR TITLE
Create a decrement view, and update route names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["J. Cliff Dyer <jcd@sdf.org>"]
 
 [dependencies]
+chrono = "0.3"
 rocket = "0.2"
 rocket_codegen = "0.2"
 serde = "0.9"

--- a/src/assignments.rs
+++ b/src/assignments.rs
@@ -1,24 +1,35 @@
 use super::keys;
+use super::date::Date;
 
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Assignment {
     learner: String,
     completed: u32,
+    date: Date,
     pub units: Vec<keys::UsageKey>,
 }
 
 
 impl Assignment {
-    pub fn new(learner: String, units: Vec<keys::UsageKey>) -> Assignment {
+    pub fn new(learner: String, dt: Date, units: Vec<keys::UsageKey>) -> Assignment {
         Assignment {
             learner: learner,
             completed: 0,
+            date: dt,
             units: units,
         }
     }
+
     pub fn increment_completed(&mut self) {
-        self.completed += 1;
+        if self.completed < self.units.len() as u32 {
+            self.completed += 1;
+        }
     }
 
+    pub fn decrement_completed(&mut self) {
+        if self.completed > 0 {
+            self.completed -= 1;
+        }
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -36,11 +36,11 @@ pub fn get_blocks(course: &CourseKey) -> Vec<UsageKey> {
     match course {
         &CourseKey { ref org, .. } if org == &"LongfellowX" => parseable(vec![
             "block-v1:LongfellowX+PaulReveresRide+1775T1+type@vertical+block@signal",
-            "block-v1:LongfellowX+PaulReveresRide+1775T1+type@vertical+block@church",
+            "block-v1:LongfellowX+PaulReveresRide+1775T1+type@sequential+block@church",
         ]),
         &CourseKey { ref org, .. } if org == &"EduCauseX" => parseable(vec![
             "block-v1:EduCauseX+TeamBasedLearning+2017T1+type@vertical+block@think-pair-share",
-            "block-v1:EduCauseX+TeamBasedLearning+2017T1+type@vertical+block@flipped-class",
+            "block-v1:EduCauseX+TeamBasedLearning+2017T1+type@unit+block@flipped-class",
         ]),
         _ => vec![],
     }

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+use std::str::FromStr;
+
+use rocket::request::FromParam;
+use serde::ser::{Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Date(u16, u16, u16); // Year, Month, Day
+
+
+impl fmt::Display for Date {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}-{:02}-{:02}", self.0, self.1, self.2)
+    }
+}
+
+
+impl Serialize for Date {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&format!("{}", self))
+    }
+}
+
+
+impl FromStr for Date {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let segs: Result<Vec<_>, _> = s.split('-').map(|x| x.parse::<u16>()).collect();
+        match segs {
+            Ok(segs) => match (segs.get(0), segs.get(1), segs.get(2), segs.get(3)) { 
+                (Some(year), Some(month), Some(day), None) => Ok(Date(*year, *month, *day)),
+                _ => Err(format!("Not a valid date: {}", s))
+            },
+            Err(err) => Err(format!("Not a valid date: {}.  Error: {:?}", s, err))
+        }
+    }
+}
+
+
+impl <'a> FromParam<'a> for Date {
+    type Error = String;
+
+    fn from_param(param: &'a str) -> Result<Self, Self::Error> {
+        param.parse()
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -15,6 +15,7 @@ pub struct CourseKey {
     pub run: String,
 }
 
+
 impl CourseKey {
     pub fn new(org: String, course: String, run: String) -> CourseKey {
         CourseKey {
@@ -24,14 +25,14 @@ impl CourseKey {
         }
     }
 
-    fn short_fmt(&self) -> String {
+    fn display_fragment(&self) -> String {
        format!("{}+{}+{}", self.org, self.course, self.run)
     }
 }
 
 impl fmt::Display for CourseKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "course-v1:{}", self.short_fmt())
+        write!(f, "course-v1:{}", self.display_fragment())
     }
 }
 
@@ -103,7 +104,13 @@ impl UsageKey {
 
 impl fmt::Display for UsageKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "block-v1:{}+type@{}+block@{}", self.course_key.short_fmt(), self.block_type, self.block_id)
+        write!(
+            f,
+            "block-v1:{}+type@{}+block@{}",
+            self.course_key.display_fragment(),
+            self.block_type,
+            self.block_id,
+        )
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ mod keys;
 
 struct AssignmentState(Arc<Mutex<HashMap<(String, Date), Assignment>>>);
 
-#[get("/assignment/<learner>/<dt>")]
+#[get("/<learner>/<dt>")]
 fn assignment(learner: String, dt: Date, asgn_state: State<AssignmentState>) -> Option<JSON<Assignment>> {
     let mut asgns = asgn_state.0.lock().unwrap();
     let asgn = asgns.entry((learner.clone(), dt.clone())).or_insert_with(move || {
@@ -42,7 +42,7 @@ fn assignment(learner: String, dt: Date, asgn_state: State<AssignmentState>) -> 
 }
 
 
-#[post("/assignment/<learner>/<dt>")]
+#[post("/<learner>/<dt>")]
 fn complete_block(learner: String, dt: Date, asgn_state: State<AssignmentState>) -> Option<JSON<Assignment>> {
     let mut asgns = asgn_state.0.lock().unwrap();
     if let Some(asgn) = asgns.get_mut(&(learner.clone(), dt)) {
@@ -53,7 +53,7 @@ fn complete_block(learner: String, dt: Date, asgn_state: State<AssignmentState>)
     }
 }
 
-#[delete("/assignment/<learner>/<dt>")]
+#[delete("/<learner>/<dt>")]
 fn uncomplete_block(learner: String, dt: Date, asgn_state: State<AssignmentState>) -> Option<JSON<Assignment>> {
     let mut asgns = asgn_state.0.lock().unwrap();
     if let Some(asgn) = asgns.get_mut(&(learner.clone(), dt)) {
@@ -67,7 +67,7 @@ fn uncomplete_block(learner: String, dt: Date, asgn_state: State<AssignmentState
 fn main() {
     let asgns: AssignmentState = AssignmentState(Arc::new(Mutex::new(HashMap::new())));
     rocket::ignite().mount(
-        "/",
+        "/dailyedx",
         routes![
             assignment,
             complete_block,


### PR DESCRIPTION
I added a view at DELETE /dailyedx/<username>/<date> to decrement the "completed" number.  So now we have 

```
GET /dailyedx/<username>/<date>
POST  /dailyedx/<username>/<date>
DELETE /dailyedx/<username>/<date>
```

My vision for this demo version is that the front end will basically do a GET to see what the daily assignment is, and then access `asgn.units[asgn.completed]` to get the next uncompleted block.  When the user is done (clicks Next), send a POST.  When `asgn.completed == len(asgn.units)`, the assignment is complete.  The learner can then watch puppy videos.  The DELETE endpoint can be used to "uncomplete" a block, and navigate backwards.
